### PR TITLE
Move lib to dlopenlibs

### DIFF
--- a/halsim-gui/pyproject.toml
+++ b/halsim-gui/pyproject.toml
@@ -13,7 +13,7 @@ baseurl = "https://frcmaven.wpi.edu/artifactory/release/edu/wpi/first/halsim"
 version = "2020.1.2"
 
 depends = ["wpilibc"]
-libs = ["halsim_gui"]
+dlopenlibs = ["halsim_gui"]
 
 
 [tool.robotpy-build.metadata]


### PR DESCRIPTION
Specify that the lib is link only.

Note: This PR depends on robotpy/robotpy-build#29 merging.